### PR TITLE
Add a few more sources for developer documentation

### DIFF
--- a/devdocs.optic
+++ b/devdocs.optic
@@ -103,7 +103,19 @@ Rule {
         Site("|code.visualstudio.com|"),
         Url("api")
     },
-    Matches { // Microsoft APIs and languages 
+    Matches { // Microsoft APIs and languages
         Site("|learn.microsoft.com|")
+    },
+    Matches {
+        Site("|docs.saltproject.io|")
+    },
+    Matches {
+        Site("|developer.hashicorp.com|")
+    },
+    Matches {
+        Domain("|go.dev|")
+    },
+    Matches {
+        Site("|docs.docker.com|")
     }
 };


### PR DESCRIPTION
This adds a few doc sites that I consult regularly:

- [Saltstack](https://docs.saltproject.io/)
- [Hashicorp](https://developer.hashicorp.com)
- [Golang](https://go.dev/)
- [Docker](https://docs.docker.com)